### PR TITLE
pin back dep version and fix test message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "argcomplete",
   "croniter",
   "jsonschema",
-  "prometheus-aioexporter>=1.5.1",
+  "prometheus-aioexporter>=1.5.1,<2.0",
   "prometheus-client",
   "python-dateutil",
   "PyYAML",

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -882,7 +882,7 @@ class TestLoadConfig:
             load_config(fd, logger)
         assert (
             str(err.value)
-            == "Invalid config at queries/q/metrics: [] is too short"
+            == "Invalid config at queries/q/metrics: [] should be non-empty"
         )
 
     def test_load_queries_no_databases(
@@ -895,7 +895,7 @@ class TestLoadConfig:
             load_config(fd, logger)
         assert (
             str(err.value)
-            == "Invalid config at queries/q/databases: [] is too short"
+            == "Invalid config at queries/q/databases: [] should be non-empty"
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
There is a new major release of `prometheus-aioexporter` that significantly changes the metric format in a way that breaks many tests. This pins us behind that, and also tweaks some test failure message expectations that have changed in the intervening time.