### PR TITLE
Install the package, not just the requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . /srcdir
 RUN python3 -m venv /virtualenv
 ENV PATH="/virtualenv/bin:$PATH"
 RUN pip install \
-    -r /srcdir/requirements.txt \
+    -r /srcdir/ \
     cx-Oracle \
     clickhouse-sqlalchemy \
     "ibm-db-sa; platform_machine == 'x86_64' or platform_machine == 'ppc64le'" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . /srcdir
 RUN python3 -m venv /virtualenv
 ENV PATH="/virtualenv/bin:$PATH"
 RUN pip install \
-    -r /srcdir/ \
+    /srcdir/ \
     cx-Oracle \
     clickhouse-sqlalchemy \
     "ibm-db-sa; platform_machine == 'x86_64' or platform_machine == 'ppc64le'" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . /srcdir
 RUN python3 -m venv /virtualenv
 ENV PATH="/virtualenv/bin:$PATH"
 RUN pip install \
-    /srcdir/ \
+    /srcdir[testing] \
     cx-Oracle \
     clickhouse-sqlalchemy \
     "ibm-db-sa; platform_machine == 'x86_64' or platform_machine == 'ppc64le'" \


### PR DESCRIPTION
Install the local package rather than just the requirements file, so that the `query-exporter` cli command is available.